### PR TITLE
Enable abstract Krosstalk subclasses

### DIFF
--- a/.idea/modules/krosstalk.iml
+++ b/.idea/modules/krosstalk.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$/../.." />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Next
+## Next (1.1.0)
 
 Breaking changes:
 
@@ -11,8 +11,10 @@ Breaking changes:
 
 Minor changes:
 
+* [#7](https://github.com/rnett/krosstalk/pull/1) Allow the use of `abstract` Krosstalk subclasses to define common
+  configuration (the README already said it was possible, but it lied).
 * [#1](https://github.com/rnett/krosstalk/pull/1) Properly throw a compiler error when trying to register a method with
-  a Krosstalk class in another module.  Would result in an ICE before.
+  a Krosstalk class in another module. Would result in an ICE before.
 
 Small unlisted changes to docs and CI.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Breaking changes:
 
 Minor changes:
 
-* [#7](https://github.com/rnett/krosstalk/pull/1) Allow the use of `abstract` Krosstalk subclasses to define common
+* [#7](https://github.com/rnett/krosstalk/pull/7) Allow the use of `abstract` Krosstalk subclasses to define common
   configuration (the README already said it was possible, but it lied).
 * [#1](https://github.com/rnett/krosstalk/pull/1) Properly throw a compiler error when trying to register a method with
   a Krosstalk class in another module. Would result in an ICE before.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
 
-    version = "1.0.1-SNAPSHOT"
+    version = "1.1.0-SNAPSHOT"
     group = "com.github.rnett.krosstalk"
 
     repositories {

--- a/compiler/krosstalk-compiler-plugin/src/main/kotlin/com/rnett/krosstalk/compiler/transformer/KrosstalkMethodTransformer.kt
+++ b/compiler/krosstalk-compiler-plugin/src/main/kotlin/com/rnett/krosstalk/compiler/transformer/KrosstalkMethodTransformer.kt
@@ -92,7 +92,10 @@ class KrosstalkMethodTransformer(
                     registerScopes()
                 }
             } else {
-                messageCollector.reportError("Can't have class extending Krosstalk that isn't an object.", declaration)
+                declaration.declarations.forEach {
+                    if(it is IrClass && it.isObject && it.isSubclassOf(Krosstalk.Scope))
+                        messageCollector.reportError("Can't have a declaration in a non-object Krosstalk class", it)
+                }
             }
         }
         return super.visitClassNew(declaration)

--- a/tests/fullstack-test/src/commonMain/kotlin/com/rnett/krosstalk/fullstack_test/Test.kt
+++ b/tests/fullstack-test/src/commonMain/kotlin/com/rnett/krosstalk/fullstack_test/Test.kt
@@ -21,13 +21,16 @@ import com.rnett.krosstalk.methodName
 import com.rnett.krosstalk.result.KrosstalkResult
 import com.rnett.krosstalk.serialization.KotlinxBinarySerializationHandler
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.Cbor
 
 @Serializable
 data class Data(val num: Int, val str: String)
 
-expect object MyKrosstalk : Krosstalk {
-    override val serialization: KotlinxBinarySerializationHandler
+abstract class BaseKrosstalk : Krosstalk() {
+    override val serialization = KotlinxBinarySerializationHandler(Cbor { })
+}
 
+expect object MyKrosstalk : BaseKrosstalk {
     object Auth : Scope
 }
 

--- a/tests/fullstack-test/src/jsMain/kotlin/com/rnett/krosstalk/fullstack_test/Test.kt
+++ b/tests/fullstack-test/src/jsMain/kotlin/com/rnett/krosstalk/fullstack_test/Test.kt
@@ -46,8 +46,7 @@ internal var lastStatusCode: Int? = null
 internal var lastHeaders: Headers? = null
     private set
 
-actual object MyKrosstalk : Krosstalk(), KrosstalkClient<KtorClientScope<*>> {
-    actual override val serialization = KotlinxBinarySerializationHandler(Cbor { })
+actual object MyKrosstalk : BaseKrosstalk(), KrosstalkClient<KtorClientScope<*>> {
     override val serverUrl: String = "http://localhost:8080"
 
     override val client = KtorClient(

--- a/tests/fullstack-test/src/jvmMain/kotlin/com/rnett/krosstalk/fullstack_test/Test.kt
+++ b/tests/fullstack-test/src/jvmMain/kotlin/com/rnett/krosstalk/fullstack_test/Test.kt
@@ -57,8 +57,7 @@ data class User(val username: String) : Principal
 
 private val validUsers = mapOf("username" to "password")
 
-actual object MyKrosstalk : Krosstalk(), KrosstalkServer<KtorServerScope<*>> {
-    actual override val serialization = KotlinxBinarySerializationHandler(Cbor { })
+actual object MyKrosstalk : BaseKrosstalk(), KrosstalkServer<KtorServerScope<*>> {
     override val server = KtorServer
 
     actual object Auth : Scope, KtorServerBasicAuth<User>("auth") {


### PR DESCRIPTION
Allows the use of abstract Krosstalk subclasses to define shared configuration, i.e. serialization.  Uses it in `fullstack_test`.